### PR TITLE
Fix server route on peers stage to avoid redirection

### DIFF
--- a/internal/stage_helpers.go
+++ b/internal/stage_helpers.go
@@ -216,7 +216,7 @@ func calculateSHA1(filePath string) (string, error) {
 
 func listenAndServePeersResponse(address string, responseContent []byte, expectedInfoHash [20]byte, fileLengthBytes int, logger *logger.Logger) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/announce/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/announce", func(w http.ResponseWriter, r *http.Request) {
 		serveTrackerResponse(w, r, responseContent, expectedInfoHash, fileLengthBytes, logger)
 	})
 


### PR DESCRIPTION
Hi! You don't have Issues in this repo, so I decided to report the problem using PR.

Disclaimer: I am not experienced into Go, but I think I figured it out right.

### Problem and solution

I am currently working at the C++ BitTorrent Challenge, Stage 8 (Peers). I have a problem with stage tests not passing. When my program requests peers by URL

```
http://127.0.0.1:46125/announce?peer_id=00112233445566778899&port=6881&uploaded=0&downloaded=0&left=2097152&compact=1&info_hash=%a1%8ay%faD%e0E%b1%e18y%16m5%82%3e%84%84%19%f8
```

it receives back

```
<a href="/announce/?peer_id=00112233445566778899&amp;port=6881&amp;uploaded=0&amp;downloaded=0&amp;left=2097152&amp;compact=1&amp;info_hash=%a1%8ay%faD%e0E%b1%e18y%16m5%82%3e%84%84%19%f8">Moved Permanently</a>
```

It doesn't look like a proper response, so I started to investigate, and I think I found a problem. As you can see, I changed a route in `listenAndServePeersResponse` function from `/announce/` to `/announce`. After that, the server started to handle my request correctly, and tests pass now.

I assume that it's a bug because routes that end with `/` appear to be routed like below

```go
mux.HandleFunc("/announce/", func(w http.ResponseWriter, r *http.Request) {
    logger.Debugf("/announce/ called")
})

// GET `/annonce/foo?<params>` -> "/announce/ called"
// GET `/annonce/?<params>` -> "/announce/ called"
// GET `/annonce?<params>` -> Moved Permanently
```

And after changes were applied like that

```go
mux.HandleFunc("/announce", func(w http.ResponseWriter, r *http.Request) {
    logger.Debugf("/announce called")
})

// GET `/annonce/foo?<params>` -> 404
// GET `/annonce/?<params>` -> 404
// GET `/annonce?<params>` -> "/announce called"
```

I could also be wrong if it's assumed by the task that `/` must be at the end of my program request URL. In that case, I believe it should be mentioned in the task description. But that also means `sample.torrent` will not work (404 returned).

**Upd:** I've just figured out that I can just follow [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) headers when I get "301 Moved Permanently". So the problem could be avoided. But again, I am not sure if it should be a problem to solve as part of the task or not.