### PR TITLE
use /announce?<param> and redirect /announce/ in tracker

### DIFF
--- a/internal/stage_handshake.go
+++ b/internal/stage_handshake.go
@@ -37,7 +37,7 @@ func testHandshake(stageHarness *tester_utils.StageHarness) error {
 	}
 
 	trackerAddress := fmt.Sprintf("127.0.0.1:%d", trackerPort)
-	trackerURL := fmt.Sprintf("http://%s/announce/", trackerAddress)
+	trackerURL := fmt.Sprintf("http://%s/announce", trackerAddress)
 	pieceLengthBytes := 1024 * 256
 	fileLengthBytes := pieceLengthBytes * len(samplePieceHashes)
 	torrent := TorrentFile{

--- a/internal/test_helpers/fixtures/handshake/with_peer_check
+++ b/internal/test_helpers/fixtures/handshake/with_peer_check
@@ -44,7 +44,7 @@ Debug = true
 [33m[stage-4] [0m[92mTest passed.[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: parse-torrent[0m
-[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1734862100/codercat.gif.torrent[0m
+[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents26616866/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -69,7 +69,7 @@ Debug = true
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-6] [0m[94mRunning tests for Stage #6: infohash[0m
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents3243348577/itsworking.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents652533747/itsworking.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2549700
 [33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
@@ -85,7 +85,7 @@ Debug = true
 [33m[your_program] [0m272a8ff8fc865b053d974a78681414b38077d7b1
 [33m[your_program] [0mb07128d3a6018062bfe779db96d3a93c05fb81d4
 [33m[your_program] [0m7affc94f0985b985eb888a36ec92652821a21be4
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents3243348577/congratulations.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents652533747/congratulations.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 820892
 [33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
@@ -95,7 +95,7 @@ Debug = true
 [33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
 [33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
 [33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents3243348577/codercat.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents652533747/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -116,7 +116,7 @@ Debug = true
 [33m[stage-6] [0m[92mTest passed.[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: hashes[0m
-[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents133247567/test.torrent[0m
+[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents3537375949/test.torrent[0m
 [33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
 [33m[your_program] [0mLength: 1835008
 [33m[your_program] [0mInfo Hash: 1840a71323682db707d1e8c9761049e875c03656
@@ -132,8 +132,8 @@ Debug = true
 [33m[stage-7] [0m[92mTest passed.[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: peers[0m
-[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents60003272/test.torrent[0m
-[33m[stage-8] [0m[36mServer started on port 127.0.0.1:51702...[0m
+[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1875521096/test.torrent[0m
+[33m[stage-8] [0m[36mServer started on port 127.0.0.1:64027...[0m
 [33m[stage-8] [0m[36m[0m
 [33m[your_program] [0m188.119.61.177:6881
 [33m[your_program] [0m71.224.0.29:51414
@@ -147,8 +147,8 @@ Debug = true
 [33m[stage-8] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: handshake[0m
-[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1698787719/test.torrent 127.0.0.1:51708[0m
-[33m[stage-9] [0m[36mServer started on port 127.0.0.1:51709...[0m
+[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1566550101/test.torrent 127.0.0.1:64029[0m
+[33m[stage-9] [0m[36mServer started on port 127.0.0.1:64030...[0m
 [33m[stage-9] [0m[36m[0m
 [33m[stage-9] [0m[36mWaiting for handshake message[0m
 [33m[stage-9] [0m[36mReceived handshake: [infohash: c7e51462e85d8631c25f8c9b8c5479345a1de26b, peer_id: 3030313132323333343435353636373738383939][0m

--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -42,7 +42,7 @@
 [33m[stage-4] [0m[92mTest passed.[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: parse-torrent[0m
-[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents804168766/codercat.gif.torrent[0m
+[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents99626081/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -65,7 +65,7 @@
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-6] [0m[94mRunning tests for Stage #6: infohash[0m
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1005924594/itsworking.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1196987747/itsworking.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2549700
 [33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
@@ -81,7 +81,7 @@
 [33m[your_program] [0m272a8ff8fc865b053d974a78681414b38077d7b1
 [33m[your_program] [0mb07128d3a6018062bfe779db96d3a93c05fb81d4
 [33m[your_program] [0m7affc94f0985b985eb888a36ec92652821a21be4
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1005924594/congratulations.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1196987747/congratulations.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 820892
 [33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
@@ -91,7 +91,7 @@
 [33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
 [33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
 [33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1005924594/codercat.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1196987747/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -112,7 +112,7 @@
 [33m[stage-6] [0m[92mTest passed.[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: hashes[0m
-[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1239034289/test.torrent[0m
+[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents948260810/test.torrent[0m
 [33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
 [33m[your_program] [0mLength: 1835008
 [33m[your_program] [0mInfo Hash: 1840a71323682db707d1e8c9761049e875c03656
@@ -128,7 +128,7 @@
 [33m[stage-7] [0m[92mTest passed.[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: peers[0m
-[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents3319336262/test.torrent[0m
+[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents4178959080/test.torrent[0m
 [33m[your_program] [0m188.119.61.177:6881
 [33m[your_program] [0m71.224.0.29:51414
 [33m[your_program] [0m62.153.208.98:3652
@@ -141,15 +141,15 @@
 [33m[stage-8] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: handshake[0m
-[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents2701476632/test.torrent 127.0.0.1:51742[0m
+[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1730116586/test.torrent 127.0.0.1:64035[0m
 [33m[your_program] [0mPeer ID: ee8f5140bfc195c36b0567cd055ac9839e682ab0
 [33m[stage-9] [0m[92mTest passed.[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: dl-piece[0m
-[33m[stage-10] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1769568918/piece-2 /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1769568918/congratulations.gif.torrent 2[0m
-[33m[stage-10] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1769568918/piece-3 /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents1769568918/congratulations.gif.torrent 3[0m
+[33m[stage-10] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1709563569/piece-2 /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1709563569/congratulations.gif.torrent 2[0m
+[33m[stage-10] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1709563569/piece-3 /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents1709563569/congratulations.gif.torrent 3[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: dl-file[0m
-[33m[stage-11] [0m[94mRunning ./your_bittorrent.sh download -o /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents227515957/codercat.gif /var/folders/79/lp3v5_c16v979pz111l0v__m0000gn/T/torrents227515957/codercat.gif.torrent[0m
+[33m[stage-11] [0m[94mRunning ./your_bittorrent.sh download -o /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents2948811282/codercat.gif /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents2948811282/codercat.gif.torrent[0m
 [33m[stage-11] [0m[92mTest passed.[0m


### PR DESCRIPTION
This PR is to fix the inconsistency between `127.0.0.1` tracker and `bittorrent-test-tracker.codecrafters.io` tracker

**Before:**
| |`/announce?<param>`|`/announce/?<param>`|
|---|---|---|
|127.0.0.1   |HTTP 301  |HTTP 200
| bittorrent-test-tracker.codecrafters.io |HTTP 200  |HTTP 301 

**After:**
| |`/announce?<param>`|`/announce/?<param>`|
|---|---|---|
|127.0.0.1   |HTTP 200  |HTTP 301
| bittorrent-test-tracker.codecrafters.io |HTTP 200  |HTTP 301 

Reported by @mrdimfox https://github.com/codecrafters-io/bittorrent-tester/pull/6