### PR TITLE
add tests for announce extension support stage

### DIFF
--- a/internal/stage_handshake.go
+++ b/internal/stage_handshake.go
@@ -60,7 +60,10 @@ func testHandshake(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	expectedReservedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	expectedReservedBytes := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 16, 0, 0},
+	}
 
 	peersResponse := createPeersResponse("127.0.0.1", peerPort)
 

--- a/internal/stage_handshake.go
+++ b/internal/stage_handshake.go
@@ -1,14 +1,11 @@
 package internal
 
 import (
-	"bytes"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"path"
 
-	logger "github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -63,9 +60,29 @@ func testHandshake(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	expectedReservedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+
 	peersResponse := createPeersResponse("127.0.0.1", peerPort)
-	go listenAndServePeersResponse(trackerAddress, peersResponse, infoHash, fileLengthBytes, logger)
-	go waitAndHandlePeerConnection(peerAddress, expectedPeerID, infoHash, logger)
+
+	go listenAndServeTrackerResponse(
+		TrackerParams {
+			trackerAddress: trackerAddress,
+			peersResponse: peersResponse,
+			expectedInfoHash: infoHash,
+			fileLengthBytes: fileLengthBytes,
+			logger: logger,
+	})
+
+	go waitAndHandlePeerConnection(
+		PeerConnectionParams {
+			address: peerAddress,
+			myPeerID: expectedPeerID,
+			infoHash: infoHash,
+			expectedReservedBytes: expectedReservedBytes,
+			logger: logger,
+		},
+		handleHandshake,
+	)
 
 	logger.Infof("Running ./%s handshake %s %s", path.Base(executable.Path), torrentFilePath, peerAddress)
 	result, err := executable.Run("handshake", torrentFilePath, peerAddress)
@@ -86,46 +103,11 @@ func testHandshake(stageHarness *test_case_harness.TestCaseHarness) error {
 	return nil
 }
 
-func randomHash() ([20]byte, error) {
-	var hash [20]byte
-	if _, err := rand.Read(hash[:]); err != nil {
-		return [20]byte{}, err
-	}
-	return hash, nil
-}
-
-func waitAndHandlePeerConnection(address string, myPeerID [20]byte, infoHash [20]byte, logger *logger.Logger) {
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		logger.Errorf("Error: %s", err)
-		return
-	}
-	defer listener.Close()
-
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			logger.Errorf("Error accepting connection: %s", err)
-		}
-		logger.Debugf("Waiting for handshake message")
-		handleConnection(conn, myPeerID, infoHash, logger)
-	}
-}
-
-func handleConnection(conn net.Conn, myPeerID [20]byte, infoHash [20]byte, logger *logger.Logger) {
+func handleHandshake(conn net.Conn, params PeerConnectionParams) {
 	defer conn.Close()
 
-	handshake, err := readHandshake(conn, logger)
+	err := receiveAndSendHandshake(conn, params)
 	if err != nil {
-		logger.Errorf("error reading handshake: %s", err)
 		return
 	}
-	if !bytes.Equal(handshake.InfoHash[:], infoHash[:]) {
-		logger.Errorf("expected infohash %x but got %x", infoHash, handshake.InfoHash)
-		return
-	}
-
-	logger.Debugf("Received handshake: [infohash: %x, peer_id: %x]\n", handshake.InfoHash, handshake.PeerID)
-	logger.Debugf("Sending back handshake with peer_id: %x", myPeerID)
-	sendHandshake(conn, handshake.InfoHash, myPeerID)
 }

--- a/internal/stage_helpers.go
+++ b/internal/stage_helpers.go
@@ -18,6 +18,29 @@ import (
 	"github.com/jackpal/bencode-go"
 )
 
+type ConnectionHandler func(net.Conn, PeerConnectionParams)
+
+type PeerConnectionParams struct {
+	address string
+	myPeerID [20]byte
+	infoHash [20]byte
+	expectedReservedBytes []byte
+	myMetadataExtensionID uint8
+	metadataSizeBytes int
+	bitfield []byte
+	magnetLink MagnetTestTorrentInfo
+	logger *logger.Logger
+}
+
+type TrackerParams struct {
+	trackerAddress string
+	peersResponse []byte
+	expectedInfoHash [20]byte
+	fileLengthBytes int
+	logger *logger.Logger
+	myMetadataExtensionID uint8
+}
+
 var samplePieceHashes = []string{
 	"ddf33172599fda84f0a209a3034f79f0b8aa5e22",
 	"795a618a1ee5275e952843b01a56ae4e142752ef",
@@ -219,10 +242,11 @@ func calculateSHA1(filePath string) (string, error) {
 	return hex.EncodeToString(hashBytes), nil
 }
 
-func listenAndServePeersResponse(address string, responseContent []byte, expectedInfoHash [20]byte, fileLengthBytes int, logger *logger.Logger) {
+func listenAndServeTrackerResponse(p TrackerParams) {
+	logger := p.logger
 	mux := http.NewServeMux()
 	mux.HandleFunc("/announce", func(w http.ResponseWriter, r *http.Request) {
-		serveTrackerResponse(w, r, responseContent, expectedInfoHash, fileLengthBytes, logger)
+		serveTrackerResponse(w, r, p.peersResponse, p.expectedInfoHash, p.fileLengthBytes, p.logger)
 	})
 	
 	// Redirect /announce/ to /announce while preserving query parameters 
@@ -237,8 +261,8 @@ func listenAndServePeersResponse(address string, responseContent []byte, expecte
 		http.Redirect(w, r, parsedURL.String(), http.StatusMovedPermanently)
 	})
 
-	logger.Debugf("Server started on port %s...\n", address)
-	err := http.ListenAndServe(address, mux)
+	logger.Debugf("Tracker started on address %s...\n", p.trackerAddress)
+	err := http.ListenAndServe(p.trackerAddress, mux)
 	if err != nil {
 		logger.Errorf("Error: %s", err)
 	}
@@ -379,4 +403,61 @@ func createPeersResponse(peerIP string, peerPort int) []byte {
 		return nil
 	}
 	return buf.Bytes()
+}
+
+func receiveAndSendHandshake(conn net.Conn, peer PeerConnectionParams) (err error) {
+	defer logOnExit(peer.logger, &err)
+
+	logger := peer.logger
+	handshake, err := readHandshake(conn, logger)
+	if err != nil {
+		return fmt.Errorf("error reading handshake: %s", err)
+	}
+	
+	if !bytes.Equal(handshake.Reserved[:], peer.expectedReservedBytes) {
+		return fmt.Errorf("did you send reserved bytes? expected bytes: %v but received: %v", peer.expectedReservedBytes, handshake.Reserved)
+	}
+
+	if !bytes.Equal(handshake.InfoHash[:], peer.infoHash[:]) {
+		return fmt.Errorf("expected infohash %x but got %x", peer.infoHash, handshake.InfoHash)
+	}
+
+	logger.Debugf("Received handshake: [infohash: %x, peer_id: %x]\n", handshake.InfoHash, handshake.PeerID)
+	logger.Debugf("Sending back handshake with peer_id: %x", peer.myPeerID)
+	
+	var reservedBytes [8]byte 
+	copy(reservedBytes[:], peer.expectedReservedBytes)
+
+	err = sendHandshake(conn, reservedBytes, handshake.InfoHash, peer.myPeerID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitAndHandlePeerConnection(p PeerConnectionParams, handler ConnectionHandler) {
+	logger := p.logger
+	logger.Debugf("Peer listening on address: %s", p.address)
+	listener, err := net.Listen("tcp", p.address)
+	if err != nil {
+		logger.Errorf("Error: %s", err)
+		return
+	}
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			logger.Errorf("Error accepting connection: %s", err)
+		}
+		handler(conn, p)
+	}
+}
+
+func randomHash() ([20]byte, error) {
+	var hash [20]byte
+	if _, err := rand.Read(hash[:]); err != nil {
+		return [20]byte{}, err
+	}
+	return hash, nil
 }

--- a/internal/stage_magnet_helpers.go
+++ b/internal/stage_magnet_helpers.go
@@ -92,7 +92,7 @@ func (m *MagnetTestParams) toPeerConnectionParams() PeerConnectionParams {
 		address: m.PeerAddress,
 		myPeerID: m.ExpectedPeerID,
 		infoHash: m.ExpectedInfoHash,
-		expectedReservedBytes: m.ExpectedReservedBytes,
+		expectedReservedBytes: [][]byte{m.ExpectedReservedBytes},
 		myMetadataExtensionID: m.MyMetadataExtensionID,
 		metadataSizeBytes: m.MagnetLinkInfo.MetadataSizeBytes,
 		bitfield: m.MagnetLinkInfo.Bitfield,

--- a/internal/stage_magnet_helpers.go
+++ b/internal/stage_magnet_helpers.go
@@ -1,5 +1,27 @@
 package internal
 
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+
+	logger "github.com/codecrafters-io/tester-utils/logger"
+)
+
+type MagnetTestParams struct {
+	TrackerAddress         string
+	PeerPort               int
+	PeerAddress            string
+	PeersResponse          []byte
+	ExpectedInfoHash       [20]byte
+	ExpectedReservedBytes  []byte
+	ExpectedPeerID         [20]byte
+	MyMetadataExtensionID  uint8
+	MagnetUrlEncoded       string
+	MagnetLinkInfo         MagnetTestTorrentInfo
+	Logger                 *logger.Logger
+}
+
 type MagnetTestTorrentInfo struct {
 	Filename           string
 	InfoHashStr        string
@@ -52,4 +74,78 @@ var magnetTestTorrents = []MagnetTestTorrentInfo {
 		Bitfield: []byte {224},
 		ExpectedSha1: "b1807e3d7920a559df2a2f0f555a404dec66a63e",
 	},
+}
+
+func (m *MagnetTestParams) toTrackerParams() TrackerParams {
+	return TrackerParams {
+		trackerAddress: m.TrackerAddress,
+		peersResponse: m.PeersResponse,
+		expectedInfoHash: m.ExpectedInfoHash,
+		fileLengthBytes: m.MagnetLinkInfo.FileLengthBytes,
+		logger: m.Logger,
+		myMetadataExtensionID: m.MyMetadataExtensionID,
+	}
+}
+
+func (m *MagnetTestParams) toPeerConnectionParams() PeerConnectionParams {
+	return PeerConnectionParams {
+		address: m.PeerAddress,
+		myPeerID: m.ExpectedPeerID,
+		infoHash: m.ExpectedInfoHash,
+		expectedReservedBytes: m.ExpectedReservedBytes,
+		myMetadataExtensionID: m.MyMetadataExtensionID,
+		metadataSizeBytes: m.MagnetLinkInfo.MetadataSizeBytes,
+		bitfield: m.MagnetLinkInfo.Bitfield,
+		magnetLink: m.MagnetLinkInfo,
+		logger: m.Logger,
+	}
+}
+
+func NewMagnetTestParams(magnetLink MagnetTestTorrentInfo, logger *logger.Logger) (*MagnetTestParams, error) {
+	params := MagnetTestParams{}
+
+	peerPort, err := findFreePort()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find free port: %s", err)
+	}
+	params.PeerPort = peerPort
+	params.PeerAddress = fmt.Sprintf("127.0.0.1:%d", peerPort)
+	params.PeersResponse = createPeersResponse("127.0.0.1", peerPort)
+
+	trackerPort, err := findFreePort()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find free port: %s", err)
+	}
+	trackerAddress :=  fmt.Sprintf("127.0.0.1:%d", trackerPort)
+	params.TrackerAddress = trackerAddress
+
+	infoHashStr := magnetLink.InfoHashStr
+	params.MagnetUrlEncoded = "magnet:?xt=urn:btih:" + infoHashStr + "&dn=" + magnetLink.Filename + "&tr=http%3A%2F%2F" + trackerAddress + "%2Fannounce"
+
+	infoHash, err := decodeInfoHash(infoHashStr)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding infohash: %v", err)
+	}
+	params.ExpectedInfoHash = infoHash
+
+	expectedPeerID, err := randomHash()
+	if err != nil {
+		return nil, fmt.Errorf("error generating random peer id: %v", err)
+	}
+	params.ExpectedPeerID = expectedPeerID
+	params.ExpectedReservedBytes = []byte{0, 0, 0, 0, 0, 16, 0, 0}
+	params.MyMetadataExtensionID = uint8(rand.Intn(255) + 1)
+	params.MagnetLinkInfo = magnetLink
+	params.Logger = logger
+	return &params, nil
+}
+
+func decodeInfoHash(infoHashStr string) ([20]byte, error) {
+	var infoHash [20]byte
+	decodedBytes, err := hex.DecodeString(infoHashStr)
+	if err != nil {
+		return infoHash, err
+	}
+	copy(infoHash[:], decodedBytes)
+	return infoHash, nil
 }

--- a/internal/stage_magnet_reserved.go
+++ b/internal/stage_magnet_reserved.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testMagnetReserved(stageHarness *test_case_harness.TestCaseHarness) error {
+    initRandom()
+
+    logger := stageHarness.Logger
+    executable := stageHarness.Executable
+
+    magnetLink := randomMagnetLink()
+    params, err := NewMagnetTestParams(magnetLink, logger)
+    if err != nil {
+        return err
+    }
+
+    go listenAndServeTrackerResponse(params.toTrackerParams())
+    go waitAndHandlePeerConnection(params.toPeerConnectionParams(), handleReservedBytes)
+
+    logger.Infof("Running ./your_bittorrent.sh magnet_handshake %q", params.MagnetUrlEncoded)
+    result, err := executable.Run("magnet_handshake", params.MagnetUrlEncoded)
+    if err != nil {
+        return err
+    }
+    
+    if err = assertExitCode(result, 0); err != nil {
+        return err
+    }
+
+    expected := fmt.Sprintf("Peer ID: %x\n", params.ExpectedPeerID)
+
+    if err = assertStdoutContains(result, expected); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+func handleReservedBytes(conn net.Conn, params PeerConnectionParams) {
+    defer conn.Close()
+
+    if err := receiveAndSendHandshake(conn, params); err != nil {
+        return
+    }
+}

--- a/internal/stage_peers.go
+++ b/internal/stage_peers.go
@@ -112,7 +112,13 @@ func testDiscoverPeers(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	go listenAndServePeersResponse(address, peersResponse, expectedInfoHash, fileLengthBytes, logger)
+	go listenAndServeTrackerResponse(TrackerParams {
+		trackerAddress: address,
+		peersResponse: peersResponse,
+		expectedInfoHash: expectedInfoHash,
+		fileLengthBytes: fileLengthBytes,
+		logger: logger,
+	})
 
 	logger.Infof("Running ./%s peers %s", path.Base(executable.Path), torrentFilePath)
 	result, err := executable.Run("peers", torrentFilePath)

--- a/internal/test_helpers/fixtures/handshake/with_peer_check
+++ b/internal/test_helpers/fixtures/handshake/with_peer_check
@@ -1,10 +1,10 @@
 Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: ca4[0m
-[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents459831871/test.torrent 127.0.0.1:46425[0m
-[33m[stage-9] [0m[36mServer started on port 127.0.0.1:33805...[0m
+[33m[stage-9] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents2160693173/test.torrent 127.0.0.1:51891[0m
+[33m[stage-9] [0m[36mTracker started on address 127.0.0.1:51892...[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[36mWaiting for handshake message[0m
+[33m[stage-9] [0m[36mPeer listening on address: 127.0.0.1:51891[0m
 [33m[stage-9] [0m[36mReceived handshake: [infohash: c7e51462e85d8631c25f8c9b8c5479345a1de26b, peer_id: 3030313132323333343435353636373738383939][0m
 [33m[stage-9] [0m[36m[0m
 [33m[stage-9] [0m[36mSending back handshake with peer_id: ee8f5140bfc195c36b0567cd055ac9839e682ab0[0m
@@ -12,8 +12,8 @@ Debug = true
 [33m[stage-9] [0m[92mTest passed.[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: fi9[0m
-[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents3722462756/test.torrent[0m
-[33m[stage-8] [0m[36mServer started on port 127.0.0.1:36151...[0m
+[33m[stage-8] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents2154674571/test.torrent[0m
+[33m[stage-8] [0m[36mTracker started on address 127.0.0.1:51895...[0m
 [33m[stage-8] [0m[36m[0m
 [33m[your_program] [0m188.119.61.177:6881
 [33m[your_program] [0m71.224.0.29:51414
@@ -27,7 +27,7 @@ Debug = true
 [33m[stage-8] [0m[92mTest passed.[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: bf7[0m
-[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2748604680/test.torrent[0m
+[33m[stage-7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents2329058448/test.torrent[0m
 [33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
 [33m[your_program] [0mLength: 1835008
 [33m[your_program] [0mInfo Hash: 1840a71323682db707d1e8c9761049e875c03656
@@ -43,7 +43,7 @@ Debug = true
 [33m[stage-7] [0m[92mTest passed.[0m
 
 [33m[stage-6] [0m[94mRunning tests for Stage #6: rb2[0m
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2177985479/itsworking.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents682922042/itsworking.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2549700
 [33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
@@ -59,7 +59,7 @@ Debug = true
 [33m[your_program] [0m272a8ff8fc865b053d974a78681414b38077d7b1
 [33m[your_program] [0mb07128d3a6018062bfe779db96d3a93c05fb81d4
 [33m[your_program] [0m7affc94f0985b985eb888a36ec92652821a21be4
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2177985479/congratulations.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents682922042/congratulations.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 820892
 [33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
@@ -69,7 +69,7 @@ Debug = true
 [33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
 [33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
 [33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2177985479/codercat.gif.torrent[0m
+[33m[stage-6] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents682922042/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -90,7 +90,7 @@ Debug = true
 [33m[stage-6] [0m[92mTest passed.[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: ow9[0m
-[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3776668588/codercat.gif.torrent[0m
+[33m[stage-5] [0m[94mRunning ./your_bittorrent.sh info /var/folders/08/v_mzt9816270xbqv5t3xgzyr0000gn/T/torrents820544448/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,11 @@
+package internal
+
+import (
+	logger "github.com/codecrafters-io/tester-utils/logger"
+)
+
+func logOnExit(logger *logger.Logger, err *error) {
+    if *err != nil {
+        logger.Errorf("%v", *err)
+    }
+}


### PR DESCRIPTION
This PR adds a test for announce extension support stage
Added checks for reserved bytes to handshake

It also contains refactoring to support easier passing of parameters to peers goroutine:
- renamed `listenAndServePeersResponse` to `listenAndServeTrackerResponse`
- added `TrackerParams` and `PeerConnectionParams` types for easier parameter plumbing
- added `MagnetTestParams` to make it easier to create magnet tests with all parameters