### PR TITLE
add test for send metadata stage

### DIFF
--- a/internal/stage_magnet_metadata2.go
+++ b/internal/stage_magnet_metadata2.go
@@ -1,0 +1,95 @@
+package internal
+
+import (
+    "fmt"
+    "net"
+
+    "github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testMagnetSendMetadata(stageHarness *test_case_harness.TestCaseHarness) error {
+    initRandom()
+
+    logger := stageHarness.Logger
+    executable := stageHarness.Executable
+
+    magnetLink := randomMagnetLink()
+    params, err := NewMagnetTestParams(magnetLink, logger)
+    if err != nil {
+        return err
+    }
+
+    go listenAndServeTrackerResponse(params.toTrackerParams())
+    go waitAndHandlePeerConnection(params.toPeerConnectionParams(), handleSendMetadata)
+
+    logger.Infof("Running ./your_bittorrent.sh magnet_info %q", params.MagnetUrlEncoded)
+    result, err := executable.Run("magnet_info", params.MagnetUrlEncoded)
+    if err != nil {
+        return err
+    }
+
+    if err = assertExitCode(result, 0); err != nil {
+        return err
+    }
+
+    expected := fmt.Sprintf("Tracker URL: http://%s/announce", params.TrackerAddress)
+    if err = assertStdoutContains(result, expected); err != nil {
+        return err
+    }
+
+    expected = fmt.Sprintf("Length: %d", params.MagnetLinkInfo.FileLengthBytes)
+    if err = assertStdoutContains(result, expected); err != nil {
+        return err
+    }
+
+    expected = fmt.Sprintf("Info Hash: %s", params.MagnetLinkInfo.InfoHashStr)
+    if err = assertStdoutContains(result, expected); err != nil {
+        return err
+    }
+
+    expected = fmt.Sprintf("Piece Length: %d", params.MagnetLinkInfo.PieceLengthBytes)
+    if err = assertStdoutContains(result, expected); err != nil {
+        return err
+    }
+
+    pieceHashes := params.MagnetLinkInfo.PieceHashes
+    for _, pieceHash := range pieceHashes {
+        if err = assertStdoutContains(result, pieceHash); err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+
+func handleSendMetadata(conn net.Conn, params PeerConnectionParams) {
+    defer conn.Close()
+    logger := params.logger
+
+    if err := receiveAndSendHandshake(conn, params); err != nil {
+        return
+    }
+
+    if err := sendBitfieldMessage(conn, params.bitfield, logger); err != nil {
+        return
+    }
+
+    if err := sendExtensionHandshake(conn, params.myMetadataExtensionID, params.metadataSizeBytes, logger); err != nil {
+        return
+    }
+
+    theirMetadataExtensionID, err := receiveAndAssertExtensionHandshake(conn, logger)
+    if err != nil {
+        return
+    }
+
+    if err := readMetadataRequest(conn, logger); err != nil {
+        return
+    }
+
+    if err := sendMetadataResponse(conn, theirMetadataExtensionID, params.magnetLink, logger); err != nil {
+        logger.Errorln(err.Error())
+        return
+    }
+}
+


### PR DESCRIPTION
This PR is part of magnet links extension
It adds tests for receive metadata stage
The tester will check the output for tracker url, file length, info hash, piece length and piece hashes

**Stages**
> 1) Parse magnet link
> 2) Advertise extension support
> 3) Send extension handshake 
> 4) Receive extension handshake
> 5) Request metadata
> 6) Receive metadata **<--- this PR**
> 7) Download a piece
> 8) Download the whole file