### PR TITLE
add test for magnet download file stage

### DIFF
--- a/internal/stage_magnet_dl_file.go
+++ b/internal/stage_magnet_dl_file.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+    "os"
+    "path"
+
+    "github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testMagnetDownloadFile(stageHarness *test_case_harness.TestCaseHarness) error {
+    initRandom()
+
+    logger := stageHarness.Logger
+    executable := stageHarness.Executable
+
+    t := randomMagnetLink()
+
+    tempDir, err := os.MkdirTemp("", "torrents")
+    if err != nil {
+        logger.Errorln("Couldn't create temp directory")
+        return err
+    }
+    downloadedFilePath := path.Join(tempDir, t.Filename)
+    magnetUrl := "magnet:?xt=urn:btih:" + t.InfoHashStr + "&dn=" + t.Filename + "&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"
+
+    logger.Infof("Running ./your_bittorrent.sh magnet_download -o %s %q", downloadedFilePath, magnetUrl)
+    result, err := executable.Run("magnet_download", "-o", downloadedFilePath, magnetUrl)
+    if err != nil {
+        return err
+    }
+
+    if err = assertExitCode(result, 0); err != nil {
+        return err
+    }
+
+    if err = assertFileSize(downloadedFilePath, int64(t.FileLengthBytes)); err != nil {
+        return err
+    }
+
+    if err = assertFileSHA1(downloadedFilePath, t.ExpectedSha1); err != nil {
+        return err
+    }
+
+    return nil
+}


### PR DESCRIPTION
This PR is part of magnet links extension
It adds tests for download the whole file stage
The test is the same as [stage_dl_file.go](https://github.com/codecrafters-io/bittorrent-tester/blob/main/internal/stage_dl_file.go) but works with magnet links

**Stages**
> 1) Parse magnet link
> 2) Advertise extension support
> 3) Send extension handshake
> 4) Receive extension handshake
> 5) Request metadata
> 6) Receive metadata
> 7) Download a piece  
> 8) Download the whole file **<--- this PR**