### PR TITLE
improve Unexpected EOF error message

### DIFF
--- a/internal/stage_magnet_helpers.go
+++ b/internal/stage_magnet_helpers.go
@@ -173,7 +173,7 @@ func receiveAndAssertExtensionHandshake(conn net.Conn, logger *logger.Logger) (i
 
 func receiveExtensionHandshake(conn net.Conn, logger *logger.Logger) (*Message, error) {
 	logger.Debugln("Waiting to receive extension handshake message")
-	msg, err := readMessage(conn)
+	msg, err := readMessage(conn, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stage_magnet_metadata1.go
+++ b/internal/stage_magnet_metadata1.go
@@ -81,7 +81,7 @@ func readMetadataRequest(conn net.Conn, logger *logger.Logger) (err error) {
     defer logOnExit(logger, &err)
 
     logger.Debugln("Waiting to receive metadata request")
-    msg, err := readMessage(conn)
+    msg, err := readMessage(conn, logger)
     if err != nil {
         return fmt.Errorf("error reading message: %v", err.Error())
     }


### PR DESCRIPTION
This PR is to improve error messaging when tester can't read the full message

Before:
> [stage-7] error receiving extension handshake: unexpected EOF

After:
> [stage-7] Ensure message length prefix has the correct value. Also make sure you're sending correct sequence of messages.
[stage-7] error receiving extension handshake: unexpected EOF