### PR TITLE
add interval and min interval to peers response

### DIFF
--- a/internal/stage_helpers.go
+++ b/internal/stage_helpers.go
@@ -399,10 +399,11 @@ func createPeersResponse(peerIP string, peerPort int) []byte {
 	peerBytes[5] = byte(peerPort)
 
 	response := map[string]interface{}{
-		"complete":    1,
-		"incomplete":  0,
-		"mininterval": 1800,
-		"peers":       peerBytes,
+		"complete":     1,
+		"incomplete":   0,
+		"interval":     60,
+		"min interval": 60,
+		"peers":        peerBytes,
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
re: [forum 3180](https://forum.codecrafters.io/t/pk2-error-missing-field-interval-only-when-run-on-test-server-but-not-missing-it-when-run-locally/3180) thread
add missing **interval** field to internal tracker response
also change **mininterval** to **min interval** to match tracker response