### PR TITLE
Fix panic #xi4 when ext handshake is nil

### DIFF
--- a/internal/stage_magnet_helpers.go
+++ b/internal/stage_magnet_helpers.go
@@ -177,6 +177,11 @@ func receiveExtensionHandshake(conn net.Conn, logger *logger.Logger) (*Message, 
 	if err != nil {
 		return nil, err
 	}
+
+	if msg == nil {
+		return nil, fmt.Errorf("received unexpected empty message")
+	}
+
 	logger.Debugf("Received extension handshake with payload: %s", string(msg.Payload))
 	return msg, nil
 }


### PR DESCRIPTION
Context:

https://codecrafters-io.slack.com/archives/C07H9EY1Z6X/p1754058803232899

After the fix:

<img width="1686" height="758" alt="image" src="https://github.com/user-attachments/assets/c9e4133d-d24d-48f1-9e05-068127f2e818" />
