### PR TITLE
[DEBUG] This is not a PR.

### DIFF
--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -1,5 +1,6 @@
 [33m[tester::#DV7] [0m[94mRunning tests for Stage #DV7 (dv7)[0m
-[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents1249346061/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
+[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents2468262945/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
+[33m[your_program] [0mgo: downloading github.com/codecrafters-io/tester-utils v0.4.5
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
@@ -8,13 +9,13 @@
 [33m[tester::#DV7] [0m[92mTest passed.[0m
 
 [33m[tester::#QV6] [0m[94mRunning tests for Stage #QV6 (qv6)[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1581561351/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1735765539/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
 [33m[tester::#QV6] [0m[92mâœ“ Piece size is correct.[0m
 [33m[tester::#QV6] [0m[92mâœ“ Piece SHA-1 is correct.[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1581561351/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1735765539/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
@@ -23,13 +24,13 @@
 [33m[tester::#QV6] [0m[92mTest passed.[0m
 
 [33m[tester::#ZH1] [0m[94mRunning tests for Stage #ZH1 (zh1)[0m
-[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:37283%2Fannounce"[0m
+[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:36617%2Fannounce"[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: fa15a2b372c707985a22024a8e58101cc0b54af3
 [33m[your_program] [0mPeer Metadata Extension ID: 189
-[33m[your_program] [0mextended message payload ï¿½d8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:37283/announce
+[33m[your_program] [0mextended message payload ½d8:msg_typei0e5:piecei0ee
+[33m[your_program] [0mTracker URL: http://127.0.0.1:36617/announce
 [33m[your_program] [0mLength: 79752
 [33m[your_program] [0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca
 [33m[your_program] [0mPiece Length: 262144
@@ -43,13 +44,13 @@
 [33m[tester::#ZH1] [0m[92mTest passed.[0m
 
 [33m[tester::#NS5] [0m[94mRunning tests for Stage #NS5 (ns5)[0m
-[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:39023%2Fannounce"[0m
+[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:38401%2Fannounce"[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 78e636cf38a9fcc687a3bf5f5ab92fea93868e65
 [33m[your_program] [0mPeer Metadata Extension ID: 245
-[33m[your_program] [0mextended message payload ï¿½d8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:39023/announce
+[33m[your_program] [0mextended message payload õd8:msg_typei0e5:piecei0ee
+[33m[your_program] [0mTracker URL: http://127.0.0.1:38401/announce
 [33m[your_program] [0mLength: 629944
 [33m[your_program] [0mInfo Hash: c5fb9894bdaba464811b088d806bdd611ba490af
 [33m[your_program] [0mPiece Length: 262144
@@ -60,7 +61,7 @@
 [33m[tester::#NS5] [0m[92mTest passed.[0m
 
 [33m[tester::#JK6] [0m[94mRunning tests for Stage #JK6 (jk6)[0m
-[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:34541%2Fannounce"[0m
+[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:37985%2Fannounce"[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 7c0055e6127ab25ddbaa13acc6923db4753f6989
@@ -70,7 +71,7 @@
 [33m[tester::#JK6] [0m[92mTest passed.[0m
 
 [33m[tester::#XI4] [0m[94mRunning tests for Stage #XI4 (xi4)[0m
-[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:41721%2Fannounce"[0m
+[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:44777%2Fannounce"[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: faf86ef81d910bc2217168298f307e49aed536f6
@@ -78,7 +79,7 @@
 [33m[tester::#XI4] [0m[92mTest passed.[0m
 
 [33m[tester::#PK2] [0m[94mRunning tests for Stage #PK2 (pk2)[0m
-[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:44995%2Fannounce"[0m
+[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:34373%2Fannounce"[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 16ec81beaf0a50e72326b82da3af3ba167edd568
@@ -94,21 +95,21 @@
 [33m[tester::#HW0] [0m[92mTest passed.[0m
 
 [33m[tester::#JV8] [0m[94mRunning tests for Stage #JV8 (jv8)[0m
-[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /tmp/torrents2208637665/congratulations.gif /tmp/torrents2208637665/congratulations.gif.torrent[0m
+[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /tmp/torrents3595185037/congratulations.gif /tmp/torrents3595185037/congratulations.gif.torrent[0m
 [33m[tester::#JV8] [0m[92mTest passed.[0m
 
 [33m[tester::#ND2] [0m[94mRunning tests for Stage #ND2 (nd2)[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents1540198114/piece-9 /tmp/torrents1540198114/itsworking.gif.torrent 9[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents1540198114/piece-1 /tmp/torrents1540198114/itsworking.gif.torrent 1[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2244117415/piece-9 /tmp/torrents2244117415/itsworking.gif.torrent 9[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2244117415/piece-1 /tmp/torrents2244117415/itsworking.gif.torrent 1[0m
 [33m[tester::#ND2] [0m[92mTest passed.[0m
 
 [33m[tester::#CA4] [0m[94mRunning tests for Stage #CA4 (ca4)[0m
-[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents2400481753/test.torrent 127.0.0.1:35225[0m
+[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents2399597646/test.torrent 127.0.0.1:34085[0m
 [33m[your_program] [0mPeer ID: 2c2bb1a943e2cc3ae9a3daa0f208750caa5ed891
 [33m[tester::#CA4] [0m[92mTest passed.[0m
 
 [33m[tester::#FI9] [0m[94mRunning tests for Stage #FI9 (fi9)[0m
-[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents1503717763/test.torrent[0m
+[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents2211932319/test.torrent[0m
 [33m[your_program] [0m106.72.196.0:41485
 [33m[your_program] [0m188.119.61.177:6881
 [33m[your_program] [0m2.7.245.20:51413
@@ -124,7 +125,7 @@
 [33m[tester::#FI9] [0m[92mTest passed.[0m
 
 [33m[tester::#BF7] [0m[94mRunning tests for Stage #BF7 (bf7)[0m
-[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3629314450/test.torrent[0m
+[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents767102291/test.torrent[0m
 [33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
 [33m[your_program] [0mLength: 786432
 [33m[your_program] [0mInfo Hash: 34ba5b82668b31aa651f12684739a578f81d8489
@@ -136,7 +137,7 @@
 [33m[tester::#BF7] [0m[92mTest passed.[0m
 
 [33m[tester::#RB2] [0m[94mRunning tests for Stage #RB2 (rb2)[0m
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/codercat.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -154,7 +155,7 @@
 [33m[your_program] [0ma86ee6abbc30cddb800a0b62d7a296111166d839
 [33m[your_program] [0m783f52b70f0c902d56196bd3ee7f379b5db57e3b
 [33m[your_program] [0m3d8db9e34db63b4ba1be27930911aa37b3f997dd
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/congratulations.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/congratulations.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 820892
 [33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
@@ -164,7 +165,7 @@
 [33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
 [33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
 [33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/itsworking.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/itsworking.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2549700
 [33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
@@ -183,7 +184,7 @@
 [33m[tester::#RB2] [0m[92mTest passed.[0m
 
 [33m[tester::#OW9] [0m[94mRunning tests for Stage #OW9 (ow9)[0m
-[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2938343653/codercat.gif.torrent[0m
+[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2209438930/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db

--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -1,6 +1,5 @@
 [33m[tester::#DV7] [0m[94mRunning tests for Stage #DV7 (dv7)[0m
-[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents2468262945/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
-[33m[your_program] [0mgo: downloading github.com/codecrafters-io/tester-utils v0.4.5
+[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents643131048/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
@@ -9,13 +8,13 @@
 [33m[tester::#DV7] [0m[92mTest passed.[0m
 
 [33m[tester::#QV6] [0m[94mRunning tests for Stage #QV6 (qv6)[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1735765539/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1926905384/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
 [33m[tester::#QV6] [0m[92mâœ“ Piece size is correct.[0m
 [33m[tester::#QV6] [0m[92mâœ“ Piece SHA-1 is correct.[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1735765539/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1926905384/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
@@ -24,13 +23,13 @@
 [33m[tester::#QV6] [0m[92mTest passed.[0m
 
 [33m[tester::#ZH1] [0m[94mRunning tests for Stage #ZH1 (zh1)[0m
-[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:36617%2Fannounce"[0m
+[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:41697%2Fannounce"[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: fa15a2b372c707985a22024a8e58101cc0b54af3
 [33m[your_program] [0mPeer Metadata Extension ID: 189
 [33m[your_program] [0mextended message payload ½d8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:36617/announce
+[33m[your_program] [0mTracker URL: http://127.0.0.1:41697/announce
 [33m[your_program] [0mLength: 79752
 [33m[your_program] [0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca
 [33m[your_program] [0mPiece Length: 262144
@@ -44,13 +43,13 @@
 [33m[tester::#ZH1] [0m[92mTest passed.[0m
 
 [33m[tester::#NS5] [0m[94mRunning tests for Stage #NS5 (ns5)[0m
-[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:38401%2Fannounce"[0m
+[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:45603%2Fannounce"[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 78e636cf38a9fcc687a3bf5f5ab92fea93868e65
 [33m[your_program] [0mPeer Metadata Extension ID: 245
 [33m[your_program] [0mextended message payload õd8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:38401/announce
+[33m[your_program] [0mTracker URL: http://127.0.0.1:45603/announce
 [33m[your_program] [0mLength: 629944
 [33m[your_program] [0mInfo Hash: c5fb9894bdaba464811b088d806bdd611ba490af
 [33m[your_program] [0mPiece Length: 262144
@@ -61,7 +60,7 @@
 [33m[tester::#NS5] [0m[92mTest passed.[0m
 
 [33m[tester::#JK6] [0m[94mRunning tests for Stage #JK6 (jk6)[0m
-[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:37985%2Fannounce"[0m
+[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:35163%2Fannounce"[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 7c0055e6127ab25ddbaa13acc6923db4753f6989
@@ -71,7 +70,7 @@
 [33m[tester::#JK6] [0m[92mTest passed.[0m
 
 [33m[tester::#XI4] [0m[94mRunning tests for Stage #XI4 (xi4)[0m
-[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:44777%2Fannounce"[0m
+[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:42279%2Fannounce"[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: faf86ef81d910bc2217168298f307e49aed536f6
@@ -79,7 +78,7 @@
 [33m[tester::#XI4] [0m[92mTest passed.[0m
 
 [33m[tester::#PK2] [0m[94mRunning tests for Stage #PK2 (pk2)[0m
-[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:34373%2Fannounce"[0m
+[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:38585%2Fannounce"[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 16ec81beaf0a50e72326b82da3af3ba167edd568
@@ -95,21 +94,21 @@
 [33m[tester::#HW0] [0m[92mTest passed.[0m
 
 [33m[tester::#JV8] [0m[94mRunning tests for Stage #JV8 (jv8)[0m
-[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /tmp/torrents3595185037/congratulations.gif /tmp/torrents3595185037/congratulations.gif.torrent[0m
+[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /tmp/torrents1419888652/congratulations.gif /tmp/torrents1419888652/congratulations.gif.torrent[0m
 [33m[tester::#JV8] [0m[92mTest passed.[0m
 
 [33m[tester::#ND2] [0m[94mRunning tests for Stage #ND2 (nd2)[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2244117415/piece-9 /tmp/torrents2244117415/itsworking.gif.torrent 9[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2244117415/piece-1 /tmp/torrents2244117415/itsworking.gif.torrent 1[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2123538764/piece-9 /tmp/torrents2123538764/itsworking.gif.torrent 9[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents2123538764/piece-1 /tmp/torrents2123538764/itsworking.gif.torrent 1[0m
 [33m[tester::#ND2] [0m[92mTest passed.[0m
 
 [33m[tester::#CA4] [0m[94mRunning tests for Stage #CA4 (ca4)[0m
-[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents2399597646/test.torrent 127.0.0.1:34085[0m
+[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents2360517746/test.torrent 127.0.0.1:34027[0m
 [33m[your_program] [0mPeer ID: 2c2bb1a943e2cc3ae9a3daa0f208750caa5ed891
 [33m[tester::#CA4] [0m[92mTest passed.[0m
 
 [33m[tester::#FI9] [0m[94mRunning tests for Stage #FI9 (fi9)[0m
-[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents2211932319/test.torrent[0m
+[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents3858671902/test.torrent[0m
 [33m[your_program] [0m106.72.196.0:41485
 [33m[your_program] [0m188.119.61.177:6881
 [33m[your_program] [0m2.7.245.20:51413
@@ -125,7 +124,7 @@
 [33m[tester::#FI9] [0m[92mTest passed.[0m
 
 [33m[tester::#BF7] [0m[94mRunning tests for Stage #BF7 (bf7)[0m
-[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents767102291/test.torrent[0m
+[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents968859184/test.torrent[0m
 [33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
 [33m[your_program] [0mLength: 786432
 [33m[your_program] [0mInfo Hash: 34ba5b82668b31aa651f12684739a578f81d8489
@@ -137,7 +136,7 @@
 [33m[tester::#BF7] [0m[92mTest passed.[0m
 
 [33m[tester::#RB2] [0m[94mRunning tests for Stage #RB2 (rb2)[0m
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/codercat.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2909395524/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
@@ -155,7 +154,7 @@
 [33m[your_program] [0ma86ee6abbc30cddb800a0b62d7a296111166d839
 [33m[your_program] [0m783f52b70f0c902d56196bd3ee7f379b5db57e3b
 [33m[your_program] [0m3d8db9e34db63b4ba1be27930911aa37b3f997dd
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/congratulations.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2909395524/congratulations.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 820892
 [33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
@@ -165,7 +164,7 @@
 [33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
 [33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
 [33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents294795104/itsworking.gif.torrent[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2909395524/itsworking.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2549700
 [33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
@@ -184,7 +183,7 @@
 [33m[tester::#RB2] [0m[92mTest passed.[0m
 
 [33m[tester::#OW9] [0m[94mRunning tests for Stage #OW9 (ow9)[0m
-[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2209438930/codercat.gif.torrent[0m
+[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3897625914/codercat.gif.torrent[0m
 [33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
 [33m[your_program] [0mLength: 2994120
 [33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db

--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -1,6 +1,5 @@
 [33m[tester::#DV7] [0m[94mRunning tests for Stage #DV7 (dv7)[0m
 [33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents1249346061/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
-[33m[your_program] [0mgo: downloading github.com/codecrafters-io/tester-utils v0.4.5
 [33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
 [33m[your_program] [0mPeer Metadata Extension ID: 1
 [33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
@@ -29,7 +28,7 @@
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: fa15a2b372c707985a22024a8e58101cc0b54af3
 [33m[your_program] [0mPeer Metadata Extension ID: 189
-[33m[your_program] [0mextended message payload ½d8:msg_typei0e5:piecei0ee
+[33m[your_program] [0mextended message payload ï¿½d8:msg_typei0e5:piecei0ee
 [33m[your_program] [0mTracker URL: http://127.0.0.1:37283/announce
 [33m[your_program] [0mLength: 79752
 [33m[your_program] [0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca
@@ -49,7 +48,7 @@
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[your_program] [0mPeer ID: 78e636cf38a9fcc687a3bf5f5ab92fea93868e65
 [33m[your_program] [0mPeer Metadata Extension ID: 245
-[33m[your_program] [0mextended message payload õd8:msg_typei0e5:piecei0ee
+[33m[your_program] [0mextended message payload ï¿½d8:msg_typei0e5:piecei0ee
 [33m[your_program] [0mTracker URL: http://127.0.0.1:39023/announce
 [33m[your_program] [0mLength: 629944
 [33m[your_program] [0mInfo Hash: c5fb9894bdaba464811b088d806bdd611ba490af

--- a/internal/test_helpers/scenarios/pass_all/go.mod
+++ b/internal/test_helpers/scenarios/pass_all/go.mod
@@ -8,6 +8,6 @@
 
 module github.com/codecrafters-io/grep-starter-go
 
-go 1.24
+go 1.24.0
 
-require github.com/codecrafters-io/tester-utils v0.4.5
+require github.com/codecrafters-io/tester-utils v0.4.9

--- a/internal/test_helpers/scenarios/pass_all/go.sum
+++ b/internal/test_helpers/scenarios/pass_all/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.5 h1:iSyDAICLI7E8FxMwz0eMRvxCd14P7vfr0KtL8Eh5F8w=
-github.com/codecrafters-io/tester-utils v0.4.5/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.9 h1:4J9ZdYB8A2vktofPK9ZlaaXOXP1dZD9zSv6cwDZ9srU=
+github.com/codecrafters-io/tester-utils v0.4.9/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps tester-utils to v0.4.9, sets Go version to 1.24.0, updates go.sum, and refreshes pass_all test fixtures.
> 
> - **Dependencies**:
>   - Bump `github.com/codecrafters-io/tester-utils` to `v0.4.9` in `internal/test_helpers/scenarios/pass_all/go.mod`.
>   - Set Go version to `1.24.0`; update `go.sum` accordingly.
> - **Test fixtures**:
>   - Refresh `internal/test_helpers/fixtures/pass_all` outputs (temp paths/ports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb0b4746fadf3dd1d5635971ebd87dafdaefbff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->