### PR TITLE
Bump tester utils version to 0.4.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build:
 test:
 	TESTER_DIR=$(shell pwd) go test -v ./internal/
 
+record_fixtures:
+	CODECRAFTERS_RECORD_FIXTURES=true make test
+
 test_and_watch:
 	onchange '**/*' -- go test -v ./internal/
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.9
+	github.com/codecrafters-io/tester-utils v0.4.13
 	github.com/jackpal/bencode-go v1.0.2
 )
 
@@ -13,6 +13,7 @@ require (
 // replace github.com/codecrafters-io/tester-utils v0.2.1 => /Users/rohitpaulk/experiments/codecrafters/tester-utils
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/codecrafters-io/tester-utils v0.4.9 h1:4J9ZdYB8A2vktofPK9ZlaaXOXP1dZD9zSv6cwDZ9srU=
-github.com/codecrafters-io/tester-utils v0.4.9/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
+github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/internal/test_helpers/fixtures/handshake/with_peer_check
+++ b/internal/test_helpers/fixtures/handshake/with_peer_check
@@ -1,93 +1,93 @@
 [33m[tester::#CA4] [0m[94mRunning tests for Stage #CA4 (ca4)[0m
-[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents1727539375/test.torrent 127.0.0.1:33963[0m
+[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents1161049248/test.torrent 127.0.0.1:57371[0m
 [33m[tester::#CA4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#CA4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: bfcd2afa15a2b372c707985a22024a8e58101cc0
+[33m[your_program] [0m[0mPeer ID: bfcd2afa15a2b372c707985a22024a8e58101cc0[0m
 [33m[tester::#CA4] [0m[92mTest passed.[0m
 
 [33m[tester::#FI9] [0m[94mRunning tests for Stage #FI9 (fi9)[0m
-[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents1136816030/test.torrent[0m
+[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents4038796879/test.torrent[0m
 [33m[tester::#FI9] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#FI9] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#FI9] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0m188.119.61.177:6881
-[33m[your_program] [0m185.107.13.235:54542
-[33m[your_program] [0m88.99.2.101:6881
+[33m[your_program] [0m[0m188.119.61.177:6881[0m
+[33m[your_program] [0m[0m185.107.13.235:54542[0m
+[33m[your_program] [0m[0m88.99.2.101:6881[0m
 [33m[tester::#FI9] [0m[92mTest passed.[0m
 
 [33m[tester::#BF7] [0m[94mRunning tests for Stage #BF7 (bf7)[0m
-[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3062077825/test.torrent[0m
-[33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
-[33m[your_program] [0mLength: 1572864
-[33m[your_program] [0mInfo Hash: 7d96a89a3cd7f900118732ce910dcb01c710e202
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece hashes:
-[33m[your_program] [0mf3889478e636cf38a9fcc687a3bf5f5ab92fea93
-[33m[your_program] [0m868e6537287c0055e6127ab25ddbaa13acc6923d
-[33m[your_program] [0mb4753f6989f516faf86ef81d910bc2217168298f
-[33m[your_program] [0m307e49aed536f6a1e516ec81beaf0a50e72326b8
-[33m[your_program] [0m2da3af3ba167edd568791acfea2c2bb1a943e2cc
-[33m[your_program] [0m70edcac2611a8829ebf467a6849f5d8408d9d8f4
+[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents1837005172/test.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bttracker.debian.org:6969/announce[0m
+[33m[your_program] [0m[0mLength: 1572864[0m
+[33m[your_program] [0m[0mInfo Hash: 7d96a89a3cd7f900118732ce910dcb01c710e202[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece hashes:[0m
+[33m[your_program] [0m[0mf3889478e636cf38a9fcc687a3bf5f5ab92fea93[0m
+[33m[your_program] [0m[0m868e6537287c0055e6127ab25ddbaa13acc6923d[0m
+[33m[your_program] [0m[0mb4753f6989f516faf86ef81d910bc2217168298f[0m
+[33m[your_program] [0m[0m307e49aed536f6a1e516ec81beaf0a50e72326b8[0m
+[33m[your_program] [0m[0m2da3af3ba167edd568791acfea2c2bb1a943e2cc[0m
+[33m[your_program] [0m[0m70edcac2611a8829ebf467a6849f5d8408d9d8f4[0m
 [33m[tester::#BF7] [0m[92mTest passed.[0m
 
 [33m[tester::#RB2] [0m[94mRunning tests for Stage #RB2 (rb2)[0m
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents1341919077/itsworking.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 2549700
-[33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece hashes:
-[33m[your_program] [0m01cc17bbe60fa5a52f64bd5f5b64d99286d50aa5
-[33m[your_program] [0m838f703cf7f6f08d1c497ed390df78f90d5f7566
-[33m[your_program] [0m45bf10974b5816491e30628b78a382ca36c4e05f
-[33m[your_program] [0m84be4bd855b34bcedc0c6e98f66d3e7c63353d1e
-[33m[your_program] [0m86427ac94d6e4f21a6d0d6c8b7ffa4c393c3b131
-[33m[your_program] [0m7c70cd5f44d1ac5505cb855d526ceb0f5f1cd5e3
-[33m[your_program] [0m3796ab05af1fa874173a0a6c1298625ad47b4fe6
-[33m[your_program] [0m272a8ff8fc865b053d974a78681414b38077d7b1
-[33m[your_program] [0mb07128d3a6018062bfe779db96d3a93c05fb81d4
-[33m[your_program] [0m7affc94f0985b985eb888a36ec92652821a21be4
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents1341919077/congratulations.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 820892
-[33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece hashes:
-[33m[your_program] [0m3d42a20edb1cf840cd3528d3a9e921db6338a463
-[33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
-[33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
-[33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents1341919077/codercat.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 2994120
-[33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece hashes:
-[33m[your_program] [0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0
-[33m[your_program] [0mb8519b2ea9bb373ff567f644428156c98a1d00fc
-[33m[your_program] [0m9dc81366587536f48c2098a1d79692f2590fd9a6
-[33m[your_program] [0m033c61e717f8c0d1e55850680eb451e3543b6203
-[33m[your_program] [0m6f54e746ec369f65f32d45f77b1f1c37621fb965
-[33m[your_program] [0mc656704b78107ed553bd0813f92fef780267c07b
-[33m[your_program] [0m7431b8683137d20ff594b1f1bf3f8835165d68fb
-[33m[your_program] [0m0432bd8e779608d27782b779c7738062e9b50ab5
-[33m[your_program] [0md6bc0409a0f3a9503857669d47fe752d4577ea00
-[33m[your_program] [0ma86ee6abbc30cddb800a0b62d7a296111166d839
-[33m[your_program] [0m783f52b70f0c902d56196bd3ee7f379b5db57e3b
-[33m[your_program] [0m3d8db9e34db63b4ba1be27930911aa37b3f997dd
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2104776260/itsworking.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 2549700[0m
+[33m[your_program] [0m[0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece hashes:[0m
+[33m[your_program] [0m[0m01cc17bbe60fa5a52f64bd5f5b64d99286d50aa5[0m
+[33m[your_program] [0m[0m838f703cf7f6f08d1c497ed390df78f90d5f7566[0m
+[33m[your_program] [0m[0m45bf10974b5816491e30628b78a382ca36c4e05f[0m
+[33m[your_program] [0m[0m84be4bd855b34bcedc0c6e98f66d3e7c63353d1e[0m
+[33m[your_program] [0m[0m86427ac94d6e4f21a6d0d6c8b7ffa4c393c3b131[0m
+[33m[your_program] [0m[0m7c70cd5f44d1ac5505cb855d526ceb0f5f1cd5e3[0m
+[33m[your_program] [0m[0m3796ab05af1fa874173a0a6c1298625ad47b4fe6[0m
+[33m[your_program] [0m[0m272a8ff8fc865b053d974a78681414b38077d7b1[0m
+[33m[your_program] [0m[0mb07128d3a6018062bfe779db96d3a93c05fb81d4[0m
+[33m[your_program] [0m[0m7affc94f0985b985eb888a36ec92652821a21be4[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2104776260/congratulations.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 820892[0m
+[33m[your_program] [0m[0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece hashes:[0m
+[33m[your_program] [0m[0m3d42a20edb1cf840cd3528d3a9e921db6338a463[0m
+[33m[your_program] [0m[0m69f885b3988a52ffb03591985402b6d5285940ab[0m
+[33m[your_program] [0m[0m76869e6c9c1f101f94f39de153e468be6a638f4f[0m
+[33m[your_program] [0m[0mbded68d02de011a2b687f75b5833f46cce8e3e9c[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2104776260/codercat.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 2994120[0m
+[33m[your_program] [0m[0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece hashes:[0m
+[33m[your_program] [0m[0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0[0m
+[33m[your_program] [0m[0mb8519b2ea9bb373ff567f644428156c98a1d00fc[0m
+[33m[your_program] [0m[0m9dc81366587536f48c2098a1d79692f2590fd9a6[0m
+[33m[your_program] [0m[0m033c61e717f8c0d1e55850680eb451e3543b6203[0m
+[33m[your_program] [0m[0m6f54e746ec369f65f32d45f77b1f1c37621fb965[0m
+[33m[your_program] [0m[0mc656704b78107ed553bd0813f92fef780267c07b[0m
+[33m[your_program] [0m[0m7431b8683137d20ff594b1f1bf3f8835165d68fb[0m
+[33m[your_program] [0m[0m0432bd8e779608d27782b779c7738062e9b50ab5[0m
+[33m[your_program] [0m[0md6bc0409a0f3a9503857669d47fe752d4577ea00[0m
+[33m[your_program] [0m[0ma86ee6abbc30cddb800a0b62d7a296111166d839[0m
+[33m[your_program] [0m[0m783f52b70f0c902d56196bd3ee7f379b5db57e3b[0m
+[33m[your_program] [0m[0m3d8db9e34db63b4ba1be27930911aa37b3f997dd[0m
 [33m[tester::#RB2] [0m[92mTest passed.[0m
 
 [33m[tester::#OW9] [0m[94mRunning tests for Stage #OW9 (ow9)[0m
-[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents1265621409/congratulations.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 820892
-[33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece hashes:
-[33m[your_program] [0m3d42a20edb1cf840cd3528d3a9e921db6338a463
-[33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
-[33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
-[33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
+[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents249994844/congratulations.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 820892[0m
+[33m[your_program] [0m[0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece hashes:[0m
+[33m[your_program] [0m[0m3d42a20edb1cf840cd3528d3a9e921db6338a463[0m
+[33m[your_program] [0m[0m69f885b3988a52ffb03591985402b6d5285940ab[0m
+[33m[your_program] [0m[0m76869e6c9c1f101f94f39de153e468be6a638f4f[0m
+[33m[your_program] [0m[0mbded68d02de011a2b687f75b5833f46cce8e3e9c[0m
 [33m[tester::#OW9] [0m[92mTracker URL is correct[0m
 [33m[tester::#OW9] [0m[92mLength is correct[0m
 [33m[tester::#OW9] [0m[92mTest passed.[0m
@@ -95,42 +95,42 @@
 [33m[tester::#MN6] [0m[94mRunning tests for Stage #MN6 (mn6)[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode de[0m
 [33m[tester::#MN6] [0m[94mExpected output: {}[0m
-[33m[your_program] [0m{}
+[33m[your_program] [0m[0m{}[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode d3:foo9:raspberry5:helloi52ee[0m
 [33m[tester::#MN6] [0m[94mExpected output: {"foo":"raspberry","hello":52}[0m
-[33m[your_program] [0m{"foo":"raspberry","hello":52}
+[33m[your_program] [0m[0m{"foo":"raspberry","hello":52}[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode d10:inner_dictd4:key16:value14:key2i42e8:list_keyl5:item15:item2i3eeee[0m
 [33m[tester::#MN6] [0m[94mExpected output: {"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}[0m
-[33m[your_program] [0m{"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}
+[33m[your_program] [0m[0m{"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}[0m
 [33m[tester::#MN6] [0m[92mTest passed.[0m
 
 [33m[tester::#AH1] [0m[94mRunning tests for Stage #AH1 (ah1)[0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode le[0m
 [33m[tester::#AH1] [0m[94mExpected output: [][0m
-[33m[your_program] [0m[]
+[33m[your_program] [0m[0m[][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode l5:mangoi112ee[0m
 [33m[tester::#AH1] [0m[94mExpected output: ["mango",112][0m
-[33m[your_program] [0m["mango",112]
+[33m[your_program] [0m[0m["mango",112][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode lli112e5:mangoee[0m
 [33m[tester::#AH1] [0m[94mExpected output: [[112,"mango"]][0m
-[33m[your_program] [0m[[112,"mango"]]
+[33m[your_program] [0m[0m[[112,"mango"]][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode lli4eei5ee[0m
 [33m[tester::#AH1] [0m[94mExpected output: [[4],5][0m
-[33m[your_program] [0m[[4],5]
+[33m[your_program] [0m[0m[[4],5][0m
 [33m[tester::#AH1] [0m[92mTest passed.[0m
 
 [33m[tester::#EB4] [0m[94mRunning tests for Stage #EB4 (eb4)[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i111574645e[0m
-[33m[your_program] [0m111574645
+[33m[your_program] [0m[0m111574645[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i4294967300e[0m
-[33m[your_program] [0m4294967300
+[33m[your_program] [0m[0m4294967300[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i-52e[0m
-[33m[your_program] [0m-52
+[33m[your_program] [0m[0m-52[0m
 [33m[tester::#EB4] [0m[92mTest passed.[0m
 
 [33m[tester::#NS2] [0m[94mRunning tests for Stage #NS2 (ns2)[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 5:grape[0m
-[33m[your_program] [0m"grape"
+[33m[your_program] [0m[0m"grape"[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 55:http://bittorrent-test-tracker.codecrafters.io/announce[0m
-[33m[your_program] [0m"http://bittorrent-test-tracker.codecrafters.io/announce"
+[33m[your_program] [0m[0m"http://bittorrent-test-tracker.codecrafters.io/announce"[0m
 [33m[tester::#NS2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/init/failure
+++ b/internal/test_helpers/fixtures/init/failure
@@ -1,5 +1,5 @@
 [33m[tester::#NS2] [0m[94mRunning tests for Stage #NS2 (ns2)[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 4:pear[0m
-[33m[your_program] [0mLogs from your program will appear here!
+[33m[your_program] [0m[0mLogs from your program will appear here![0m
 [33m[tester::#NS2] [0m[91mExpected "\"pear\"\n" as stdout, got: "Logs from your program will appear here!\n"[0m
 [33m[tester::#NS2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/init/success
+++ b/internal/test_helpers/fixtures/init/success
@@ -1,6 +1,6 @@
 [33m[tester::#NS2] [0m[94mRunning tests for Stage #NS2 (ns2)[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 4:pear[0m
-[33m[your_program] [0m"pear"
+[33m[your_program] [0m[0m"pear"[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 55:http://bittorrent-test-tracker.codecrafters.io/announce[0m
-[33m[your_program] [0m"http://bittorrent-test-tracker.codecrafters.io/announce"
+[33m[your_program] [0m[0m"http://bittorrent-test-tracker.codecrafters.io/announce"[0m
 [33m[tester::#NS2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -1,41 +1,40 @@
 [33m[tester::#DV7] [0m[94mRunning tests for Stage #DV7 (dv7)[0m
-[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /tmp/torrents1249346061/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
-[33m[your_program] [0mgo: downloading github.com/codecrafters-io/tester-utils v0.4.5
-[33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
-[33m[your_program] [0mPeer Metadata Extension ID: 1
-[33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
+[33m[tester::#DV7] [0m[94mRunning ./your_bittorrent.sh magnet_download -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents3357971680/magnet1.gif "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
+[33m[your_program] [0m[0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 1[0m
+[33m[your_program] [0m[0mextended message payload d8:msg_typei0e5:piecei0ee[0m
 [33m[tester::#DV7] [0m[92m✓ File size is correct.[0m
 [33m[tester::#DV7] [0m[92m✓ File SHA-1 is correct.[0m
 [33m[tester::#DV7] [0m[92mTest passed.[0m
 
 [33m[tester::#QV6] [0m[94mRunning tests for Stage #QV6 (qv6)[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1581561351/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
-[33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
-[33m[your_program] [0mPeer Metadata Extension ID: 1
-[33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2957192619/piece-1 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 1[0m
+[33m[your_program] [0m[0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 1[0m
+[33m[your_program] [0m[0mextended message payload d8:msg_typei0e5:piecei0ee[0m
 [33m[tester::#QV6] [0m[92m✓ Piece size is correct.[0m
 [33m[tester::#QV6] [0m[92m✓ Piece SHA-1 is correct.[0m
-[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /tmp/torrents1581561351/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
-[33m[your_program] [0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92
-[33m[your_program] [0mPeer Metadata Extension ID: 1
-[33m[your_program] [0mextended message payload d8:msg_typei0e5:piecei0ee
+[33m[tester::#QV6] [0m[94mRunning ./your_bittorrent.sh magnet_download_piece -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2957192619/piece-2 "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce" 2[0m
+[33m[your_program] [0m[0mPeer ID: 2d524e302e302e302da410a9e293e56db57b9c92[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 1[0m
+[33m[your_program] [0m[0mextended message payload d8:msg_typei0e5:piecei0ee[0m
 [33m[tester::#QV6] [0m[92m✓ Piece size is correct.[0m
 [33m[tester::#QV6] [0m[92m✓ Piece SHA-1 is correct.[0m
 [33m[tester::#QV6] [0m[92mTest passed.[0m
 
 [33m[tester::#ZH1] [0m[94mRunning tests for Stage #ZH1 (zh1)[0m
-[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:37283%2Fannounce"[0m
+[33m[tester::#ZH1] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2F127.0.0.1:57652%2Fannounce"[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#ZH1] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: fa15a2b372c707985a22024a8e58101cc0b54af3
-[33m[your_program] [0mPeer Metadata Extension ID: 189
-[33m[your_program] [0mextended message payload �d8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:37283/announce
-[33m[your_program] [0mLength: 79752
-[33m[your_program] [0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0md78a7f55ddd89fef477bc49d938bc7e4d94094f1
+[33m[your_program] [0m[0mPeer ID: fa15a2b372c707985a22024a8e58101cc0b54af3[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 189[0m
+[33m[your_program] [0m[0mextended message payload �d8:msg_typei0e5:piecei0ee[0m
+[33m[your_program] [0m[0mTracker URL: http://127.0.0.1:57652/announce[0m
+[33m[your_program] [0m[0mLength: 79752[0m
+[33m[your_program] [0m[0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0md78a7f55ddd89fef477bc49d938bc7e4d94094f1[0m
 [33m[tester::#ZH1] [0m[92m✓ Tracker URL is correct.[0m
 [33m[tester::#ZH1] [0m[92m✓ Length is correct.[0m
 [33m[tester::#ZH1] [0m[92m✓ Info Hash is correct.[0m
@@ -44,164 +43,164 @@
 [33m[tester::#ZH1] [0m[92mTest passed.[0m
 
 [33m[tester::#NS5] [0m[94mRunning tests for Stage #NS5 (ns5)[0m
-[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:39023%2Fannounce"[0m
+[33m[tester::#NS5] [0m[94mRunning ./your_bittorrent.sh magnet_info "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:57664%2Fannounce"[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#NS5] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: 78e636cf38a9fcc687a3bf5f5ab92fea93868e65
-[33m[your_program] [0mPeer Metadata Extension ID: 245
-[33m[your_program] [0mextended message payload �d8:msg_typei0e5:piecei0ee
-[33m[your_program] [0mTracker URL: http://127.0.0.1:39023/announce
-[33m[your_program] [0mLength: 629944
-[33m[your_program] [0mInfo Hash: c5fb9894bdaba464811b088d806bdd611ba490af
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0mca80fd83ffb34d6e1bbd26a8ef6d305827f1cd0a
-[33m[your_program] [0m707fd7c657f6d636f0583466c3cfe134ddb2c08a
-[33m[your_program] [0m47076d104d214c0052960ef767262649a8af0ea8
+[33m[your_program] [0m[0mPeer ID: 78e636cf38a9fcc687a3bf5f5ab92fea93868e65[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 245[0m
+[33m[your_program] [0m[0mextended message payload �d8:msg_typei0e5:piecei0ee[0m
+[33m[your_program] [0m[0mTracker URL: http://127.0.0.1:57664/announce[0m
+[33m[your_program] [0m[0mLength: 629944[0m
+[33m[your_program] [0m[0mInfo Hash: c5fb9894bdaba464811b088d806bdd611ba490af[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0mca80fd83ffb34d6e1bbd26a8ef6d305827f1cd0a[0m
+[33m[your_program] [0m[0m707fd7c657f6d636f0583466c3cfe134ddb2c08a[0m
+[33m[your_program] [0m[0m47076d104d214c0052960ef767262649a8af0ea8[0m
 [33m[tester::#NS5] [0m[92mTest passed.[0m
 
 [33m[tester::#JK6] [0m[94mRunning tests for Stage #JK6 (jk6)[0m
-[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:34541%2Fannounce"[0m
+[33m[tester::#JK6] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:ad42ce8109f54c99613ce38f9b4d87e70f24a165&dn=magnet1.gif&tr=http%3A%2F%2F127.0.0.1:57674%2Fannounce"[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#JK6] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: 7c0055e6127ab25ddbaa13acc6923db4753f6989
-[33m[your_program] [0mPeer Metadata Extension ID: 232
+[33m[your_program] [0m[0mPeer ID: 7c0055e6127ab25ddbaa13acc6923db4753f6989[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 232[0m
 [33m[tester::#JK6] [0m[92m✓ Peer ID is correct.[0m
 [33m[tester::#JK6] [0m[92m✓ Peer Metadata Extension ID is correct.[0m
 [33m[tester::#JK6] [0m[92mTest passed.[0m
 
 [33m[tester::#XI4] [0m[94mRunning tests for Stage #XI4 (xi4)[0m
-[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:41721%2Fannounce"[0m
+[33m[tester::#XI4] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:57684%2Fannounce"[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#XI4] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: faf86ef81d910bc2217168298f307e49aed536f6
-[33m[your_program] [0mPeer Metadata Extension ID: 35
+[33m[your_program] [0m[0mPeer ID: faf86ef81d910bc2217168298f307e49aed536f6[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 35[0m
 [33m[tester::#XI4] [0m[92mTest passed.[0m
 
 [33m[tester::#PK2] [0m[94mRunning tests for Stage #PK2 (pk2)[0m
-[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:44995%2Fannounce"[0m
+[33m[tester::#PK2] [0m[94mRunning ./your_bittorrent.sh magnet_handshake "magnet:?xt=urn:btih:c5fb9894bdaba464811b088d806bdd611ba490af&dn=magnet3.gif&tr=http%3A%2F%2F127.0.0.1:57695%2Fannounce"[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
 [33m[tester::#PK2] [0m[91mWARNING: Common peer_ids like 00112233445566778899 are prone to collisions with other clients. Peers may only accept one connection per peer_id, increasing the chance of seeing 'Connection reset by peer' errors. Use a random peer_id instead.[0m
-[33m[your_program] [0mPeer ID: 16ec81beaf0a50e72326b82da3af3ba167edd568
-[33m[your_program] [0mPeer Metadata Extension ID: 240
+[33m[your_program] [0m[0mPeer ID: 16ec81beaf0a50e72326b82da3af3ba167edd568[0m
+[33m[your_program] [0m[0mPeer Metadata Extension ID: 240[0m
 [33m[tester::#PK2] [0m[92mTest passed.[0m
 
 [33m[tester::#HW0] [0m[94mRunning tests for Stage #HW0 (hw0)[0m
 [33m[tester::#HW0] [0m[94mRunning ./your_bittorrent.sh magnet_parse "magnet:?xt=urn:btih:3f994a835e090238873498636b98a3e78d1c34ca&dn=magnet2.gif&tr=http%3A%2F%2Fbittorrent-test-tracker.codecrafters.io%2Fannounce"[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mInfo Hash: 3f994a835e090238873498636b98a3e78d1c34ca[0m
 [33m[tester::#HW0] [0m[92m✓ Info Hash is correct.[0m
 [33m[tester::#HW0] [0m[92m✓ Tracker URL is correct.[0m
 [33m[tester::#HW0] [0m[92mTest passed.[0m
 
 [33m[tester::#JV8] [0m[94mRunning tests for Stage #JV8 (jv8)[0m
-[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /tmp/torrents2208637665/congratulations.gif /tmp/torrents2208637665/congratulations.gif.torrent[0m
+[33m[tester::#JV8] [0m[94mRunning ./your_bittorrent.sh download -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2458111914/congratulations.gif /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2458111914/congratulations.gif.torrent[0m
 [33m[tester::#JV8] [0m[92mTest passed.[0m
 
 [33m[tester::#ND2] [0m[94mRunning tests for Stage #ND2 (nd2)[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents1540198114/piece-9 /tmp/torrents1540198114/itsworking.gif.torrent 9[0m
-[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /tmp/torrents1540198114/piece-1 /tmp/torrents1540198114/itsworking.gif.torrent 1[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2180300463/piece-9 /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2180300463/itsworking.gif.torrent 9[0m
+[33m[tester::#ND2] [0m[94mRunning ./your_bittorrent.sh download_piece -o /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2180300463/piece-1 /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2180300463/itsworking.gif.torrent 1[0m
 [33m[tester::#ND2] [0m[92mTest passed.[0m
 
 [33m[tester::#CA4] [0m[94mRunning tests for Stage #CA4 (ca4)[0m
-[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /tmp/torrents2400481753/test.torrent 127.0.0.1:35225[0m
-[33m[your_program] [0mPeer ID: 2c2bb1a943e2cc3ae9a3daa0f208750caa5ed891
+[33m[tester::#CA4] [0m[94mRunning ./your_bittorrent.sh handshake /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents2446147437/test.torrent 127.0.0.1:57731[0m
+[33m[your_program] [0m[0mPeer ID: 2c2bb1a943e2cc3ae9a3daa0f208750caa5ed891[0m
 [33m[tester::#CA4] [0m[92mTest passed.[0m
 
 [33m[tester::#FI9] [0m[94mRunning tests for Stage #FI9 (fi9)[0m
-[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /tmp/torrents1503717763/test.torrent[0m
-[33m[your_program] [0m106.72.196.0:41485
-[33m[your_program] [0m188.119.61.177:6881
-[33m[your_program] [0m2.7.245.20:51413
-[33m[your_program] [0m71.224.0.29:51414
-[33m[your_program] [0m37.48.74.20:44697
-[33m[your_program] [0m82.149.227.229:6890
-[33m[your_program] [0m72.175.28.2:58966
-[33m[your_program] [0m45.67.229.74:60007
-[33m[your_program] [0m195.90.215.221:45682
-[33m[your_program] [0m66.55.206.70:60000
-[33m[your_program] [0m69.53.20.159:60000
-[33m[your_program] [0m216.195.129.27:60000
+[33m[tester::#FI9] [0m[94mRunning ./your_bittorrent.sh peers /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents4056082742/test.torrent[0m
+[33m[your_program] [0m[0m106.72.196.0:41485[0m
+[33m[your_program] [0m[0m188.119.61.177:6881[0m
+[33m[your_program] [0m[0m2.7.245.20:51413[0m
+[33m[your_program] [0m[0m71.224.0.29:51414[0m
+[33m[your_program] [0m[0m37.48.74.20:44697[0m
+[33m[your_program] [0m[0m82.149.227.229:6890[0m
+[33m[your_program] [0m[0m72.175.28.2:58966[0m
+[33m[your_program] [0m[0m45.67.229.74:60007[0m
+[33m[your_program] [0m[0m195.90.215.221:45682[0m
+[33m[your_program] [0m[0m66.55.206.70:60000[0m
+[33m[your_program] [0m[0m69.53.20.159:60000[0m
+[33m[your_program] [0m[0m216.195.129.27:60000[0m
 [33m[tester::#FI9] [0m[92mTest passed.[0m
 
 [33m[tester::#BF7] [0m[94mRunning tests for Stage #BF7 (bf7)[0m
-[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3629314450/test.torrent[0m
-[33m[your_program] [0mTracker URL: http://bttracker.debian.org:6969/announce
-[33m[your_program] [0mLength: 786432
-[33m[your_program] [0mInfo Hash: 34ba5b82668b31aa651f12684739a578f81d8489
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0m56147a0aafe287bf309bf0be558b9d73b48cbd76
-[33m[your_program] [0m1fe5ecefc0b284ab90fc741d89788cf3316b05b1
-[33m[your_program] [0m70edcac2611a8829ebf467a6849f5d8408d9d8f4
+[33m[tester::#BF7] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents3591951970/test.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bttracker.debian.org:6969/announce[0m
+[33m[your_program] [0m[0mLength: 786432[0m
+[33m[your_program] [0m[0mInfo Hash: 34ba5b82668b31aa651f12684739a578f81d8489[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0m56147a0aafe287bf309bf0be558b9d73b48cbd76[0m
+[33m[your_program] [0m[0m1fe5ecefc0b284ab90fc741d89788cf3316b05b1[0m
+[33m[your_program] [0m[0m70edcac2611a8829ebf467a6849f5d8408d9d8f4[0m
 [33m[tester::#BF7] [0m[92mTest passed.[0m
 
 [33m[tester::#RB2] [0m[94mRunning tests for Stage #RB2 (rb2)[0m
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/codercat.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 2994120
-[33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0
-[33m[your_program] [0mb8519b2ea9bb373ff567f644428156c98a1d00fc
-[33m[your_program] [0m9dc81366587536f48c2098a1d79692f2590fd9a6
-[33m[your_program] [0m033c61e717f8c0d1e55850680eb451e3543b6203
-[33m[your_program] [0m6f54e746ec369f65f32d45f77b1f1c37621fb965
-[33m[your_program] [0mc656704b78107ed553bd0813f92fef780267c07b
-[33m[your_program] [0m7431b8683137d20ff594b1f1bf3f8835165d68fb
-[33m[your_program] [0m0432bd8e779608d27782b779c7738062e9b50ab5
-[33m[your_program] [0md6bc0409a0f3a9503857669d47fe752d4577ea00
-[33m[your_program] [0ma86ee6abbc30cddb800a0b62d7a296111166d839
-[33m[your_program] [0m783f52b70f0c902d56196bd3ee7f379b5db57e3b
-[33m[your_program] [0m3d8db9e34db63b4ba1be27930911aa37b3f997dd
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/congratulations.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 820892
-[33m[your_program] [0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0m3d42a20edb1cf840cd3528d3a9e921db6338a463
-[33m[your_program] [0m69f885b3988a52ffb03591985402b6d5285940ab
-[33m[your_program] [0m76869e6c9c1f101f94f39de153e468be6a638f4f
-[33m[your_program] [0mbded68d02de011a2b687f75b5833f46cce8e3e9c
-[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents3452503248/itsworking.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 2549700
-[33m[your_program] [0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0m01cc17bbe60fa5a52f64bd5f5b64d99286d50aa5
-[33m[your_program] [0m838f703cf7f6f08d1c497ed390df78f90d5f7566
-[33m[your_program] [0m45bf10974b5816491e30628b78a382ca36c4e05f
-[33m[your_program] [0m84be4bd855b34bcedc0c6e98f66d3e7c63353d1e
-[33m[your_program] [0m86427ac94d6e4f21a6d0d6c8b7ffa4c393c3b131
-[33m[your_program] [0m7c70cd5f44d1ac5505cb855d526ceb0f5f1cd5e3
-[33m[your_program] [0m3796ab05af1fa874173a0a6c1298625ad47b4fe6
-[33m[your_program] [0m272a8ff8fc865b053d974a78681414b38077d7b1
-[33m[your_program] [0mb07128d3a6018062bfe779db96d3a93c05fb81d4
-[33m[your_program] [0m7affc94f0985b985eb888a36ec92652821a21be4
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents734097655/codercat.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 2994120[0m
+[33m[your_program] [0m[0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0[0m
+[33m[your_program] [0m[0mb8519b2ea9bb373ff567f644428156c98a1d00fc[0m
+[33m[your_program] [0m[0m9dc81366587536f48c2098a1d79692f2590fd9a6[0m
+[33m[your_program] [0m[0m033c61e717f8c0d1e55850680eb451e3543b6203[0m
+[33m[your_program] [0m[0m6f54e746ec369f65f32d45f77b1f1c37621fb965[0m
+[33m[your_program] [0m[0mc656704b78107ed553bd0813f92fef780267c07b[0m
+[33m[your_program] [0m[0m7431b8683137d20ff594b1f1bf3f8835165d68fb[0m
+[33m[your_program] [0m[0m0432bd8e779608d27782b779c7738062e9b50ab5[0m
+[33m[your_program] [0m[0md6bc0409a0f3a9503857669d47fe752d4577ea00[0m
+[33m[your_program] [0m[0ma86ee6abbc30cddb800a0b62d7a296111166d839[0m
+[33m[your_program] [0m[0m783f52b70f0c902d56196bd3ee7f379b5db57e3b[0m
+[33m[your_program] [0m[0m3d8db9e34db63b4ba1be27930911aa37b3f997dd[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents734097655/congratulations.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 820892[0m
+[33m[your_program] [0m[0mInfo Hash: 1cad4a486798d952614c394eb15e75bec587fd08[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0m3d42a20edb1cf840cd3528d3a9e921db6338a463[0m
+[33m[your_program] [0m[0m69f885b3988a52ffb03591985402b6d5285940ab[0m
+[33m[your_program] [0m[0m76869e6c9c1f101f94f39de153e468be6a638f4f[0m
+[33m[your_program] [0m[0mbded68d02de011a2b687f75b5833f46cce8e3e9c[0m
+[33m[tester::#RB2] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents734097655/itsworking.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 2549700[0m
+[33m[your_program] [0m[0mInfo Hash: 70edcac2611a8829ebf467a6849f5d8408d9d8f4[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0m01cc17bbe60fa5a52f64bd5f5b64d99286d50aa5[0m
+[33m[your_program] [0m[0m838f703cf7f6f08d1c497ed390df78f90d5f7566[0m
+[33m[your_program] [0m[0m45bf10974b5816491e30628b78a382ca36c4e05f[0m
+[33m[your_program] [0m[0m84be4bd855b34bcedc0c6e98f66d3e7c63353d1e[0m
+[33m[your_program] [0m[0m86427ac94d6e4f21a6d0d6c8b7ffa4c393c3b131[0m
+[33m[your_program] [0m[0m7c70cd5f44d1ac5505cb855d526ceb0f5f1cd5e3[0m
+[33m[your_program] [0m[0m3796ab05af1fa874173a0a6c1298625ad47b4fe6[0m
+[33m[your_program] [0m[0m272a8ff8fc865b053d974a78681414b38077d7b1[0m
+[33m[your_program] [0m[0mb07128d3a6018062bfe779db96d3a93c05fb81d4[0m
+[33m[your_program] [0m[0m7affc94f0985b985eb888a36ec92652821a21be4[0m
 [33m[tester::#RB2] [0m[92mTest passed.[0m
 
 [33m[tester::#OW9] [0m[94mRunning tests for Stage #OW9 (ow9)[0m
-[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /tmp/torrents2938343653/codercat.gif.torrent[0m
-[33m[your_program] [0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce
-[33m[your_program] [0mLength: 2994120
-[33m[your_program] [0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db
-[33m[your_program] [0mPiece Length: 262144
-[33m[your_program] [0mPiece Hashes:
-[33m[your_program] [0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0
-[33m[your_program] [0mb8519b2ea9bb373ff567f644428156c98a1d00fc
-[33m[your_program] [0m9dc81366587536f48c2098a1d79692f2590fd9a6
-[33m[your_program] [0m033c61e717f8c0d1e55850680eb451e3543b6203
-[33m[your_program] [0m6f54e746ec369f65f32d45f77b1f1c37621fb965
-[33m[your_program] [0mc656704b78107ed553bd0813f92fef780267c07b
-[33m[your_program] [0m7431b8683137d20ff594b1f1bf3f8835165d68fb
-[33m[your_program] [0m0432bd8e779608d27782b779c7738062e9b50ab5
-[33m[your_program] [0md6bc0409a0f3a9503857669d47fe752d4577ea00
-[33m[your_program] [0ma86ee6abbc30cddb800a0b62d7a296111166d839
-[33m[your_program] [0m783f52b70f0c902d56196bd3ee7f379b5db57e3b
-[33m[your_program] [0m3d8db9e34db63b4ba1be27930911aa37b3f997dd
+[33m[tester::#OW9] [0m[94mRunning ./your_bittorrent.sh info /var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/torrents578252316/codercat.gif.torrent[0m
+[33m[your_program] [0m[0mTracker URL: http://bittorrent-test-tracker.codecrafters.io/announce[0m
+[33m[your_program] [0m[0mLength: 2994120[0m
+[33m[your_program] [0m[0mInfo Hash: c77829d2a77d6516f88cd7a3de1a26abcbfab0db[0m
+[33m[your_program] [0m[0mPiece Length: 262144[0m
+[33m[your_program] [0m[0mPiece Hashes:[0m
+[33m[your_program] [0m[0m3c34309faebf01e49c0f63c90b7edcc2259b6ad0[0m
+[33m[your_program] [0m[0mb8519b2ea9bb373ff567f644428156c98a1d00fc[0m
+[33m[your_program] [0m[0m9dc81366587536f48c2098a1d79692f2590fd9a6[0m
+[33m[your_program] [0m[0m033c61e717f8c0d1e55850680eb451e3543b6203[0m
+[33m[your_program] [0m[0m6f54e746ec369f65f32d45f77b1f1c37621fb965[0m
+[33m[your_program] [0m[0mc656704b78107ed553bd0813f92fef780267c07b[0m
+[33m[your_program] [0m[0m7431b8683137d20ff594b1f1bf3f8835165d68fb[0m
+[33m[your_program] [0m[0m0432bd8e779608d27782b779c7738062e9b50ab5[0m
+[33m[your_program] [0m[0md6bc0409a0f3a9503857669d47fe752d4577ea00[0m
+[33m[your_program] [0m[0ma86ee6abbc30cddb800a0b62d7a296111166d839[0m
+[33m[your_program] [0m[0m783f52b70f0c902d56196bd3ee7f379b5db57e3b[0m
+[33m[your_program] [0m[0m3d8db9e34db63b4ba1be27930911aa37b3f997dd[0m
 [33m[tester::#OW9] [0m[92mTracker URL is correct[0m
 [33m[tester::#OW9] [0m[92mLength is correct[0m
 [33m[tester::#OW9] [0m[92mTest passed.[0m
@@ -209,42 +208,42 @@
 [33m[tester::#MN6] [0m[94mRunning tests for Stage #MN6 (mn6)[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode de[0m
 [33m[tester::#MN6] [0m[94mExpected output: {}[0m
-[33m[your_program] [0m{}
+[33m[your_program] [0m[0m{}[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode d3:foo9:blueberry5:helloi52ee[0m
 [33m[tester::#MN6] [0m[94mExpected output: {"foo":"blueberry","hello":52}[0m
-[33m[your_program] [0m{"foo":"blueberry","hello":52}
+[33m[your_program] [0m[0m{"foo":"blueberry","hello":52}[0m
 [33m[tester::#MN6] [0m[94mRunning ./your_bittorrent.sh decode d10:inner_dictd4:key16:value14:key2i42e8:list_keyl5:item15:item2i3eeee[0m
 [33m[tester::#MN6] [0m[94mExpected output: {"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}[0m
-[33m[your_program] [0m{"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}
+[33m[your_program] [0m[0m{"inner_dict":{"key1":"value1","key2":42,"list_key":["item1","item2",3]}}[0m
 [33m[tester::#MN6] [0m[92mTest passed.[0m
 
 [33m[tester::#AH1] [0m[94mRunning tests for Stage #AH1 (ah1)[0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode le[0m
 [33m[tester::#AH1] [0m[94mExpected output: [][0m
-[33m[your_program] [0m[]
+[33m[your_program] [0m[0m[][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode l5:mangoi31ee[0m
 [33m[tester::#AH1] [0m[94mExpected output: ["mango",31][0m
-[33m[your_program] [0m["mango",31]
+[33m[your_program] [0m[0m["mango",31][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode lli31e5:mangoee[0m
 [33m[tester::#AH1] [0m[94mExpected output: [[31,"mango"]][0m
-[33m[your_program] [0m[[31,"mango"]]
+[33m[your_program] [0m[0m[[31,"mango"]][0m
 [33m[tester::#AH1] [0m[94mRunning ./your_bittorrent.sh decode lli4eei5ee[0m
 [33m[tester::#AH1] [0m[94mExpected output: [[4],5][0m
-[33m[your_program] [0m[[4],5]
+[33m[your_program] [0m[0m[[4],5][0m
 [33m[tester::#AH1] [0m[92mTest passed.[0m
 
 [33m[tester::#EB4] [0m[94mRunning tests for Stage #EB4 (eb4)[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i1012356670e[0m
-[33m[your_program] [0m1012356670
+[33m[your_program] [0m[0m1012356670[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i4294967300e[0m
-[33m[your_program] [0m4294967300
+[33m[your_program] [0m[0m4294967300[0m
 [33m[tester::#EB4] [0m[94mRunning ./your_bittorrent.sh decode i-52e[0m
-[33m[your_program] [0m-52
+[33m[your_program] [0m[0m-52[0m
 [33m[tester::#EB4] [0m[92mTest passed.[0m
 
 [33m[tester::#NS2] [0m[94mRunning tests for Stage #NS2 (ns2)[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 9:blueberry[0m
-[33m[your_program] [0m"blueberry"
+[33m[your_program] [0m[0m"blueberry"[0m
 [33m[tester::#NS2] [0m[94mRunning ./your_bittorrent.sh decode 55:http://bittorrent-test-tracker.codecrafters.io/announce[0m
-[33m[your_program] [0m"http://bittorrent-test-tracker.codecrafters.io/announce"
+[33m[your_program] [0m[0m"http://bittorrent-test-tracker.codecrafters.io/announce"[0m
 [33m[tester::#NS2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/scenarios/pass_all/go.mod
+++ b/internal/test_helpers/scenarios/pass_all/go.mod
@@ -10,4 +10,4 @@ module github.com/codecrafters-io/grep-starter-go
 
 go 1.24
 
-require github.com/codecrafters-io/tester-utils v0.4.5
+require github.com/codecrafters-io/tester-utils v0.4.13

--- a/internal/test_helpers/scenarios/pass_all/go.sum
+++ b/internal/test_helpers/scenarios/pass_all/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.5 h1:iSyDAICLI7E8FxMwz0eMRvxCd14P7vfr0KtL8Eh5F8w=
-github.com/codecrafters-io/tester-utils v0.4.5/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
+github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Deps:** Bump `github.com/codecrafters-io/tester-utils` to `v0.4.13` in `go.mod` and scenario `go.mod`; update `go.sum`; add indirect `github.com/creack/pty`.
> - **Fixtures:** Refresh outputs under `internal/test_helpers/fixtures/*` and `scenarios/pass_all` to reflect new paths/escape sequences from updated tester utils.
> - **Makefile:** Add `record_fixtures` target to re-run tests with `CODECRAFTERS_RECORD_FIXTURES=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a9e0d6827f94ff6a2a66abcf9f9e2d7b037ead1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->