### PR TITLE
Downgrade tester-utils version to v0.4.13 in go.mod and go.sum files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.14
+	github.com/codecrafters-io/tester-utils v0.4.13
 	github.com/jackpal/bencode-go v1.0.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.14 h1:jJ+b19Il11o/VtIRaaJNOS/HdZLB+yHqJM/P7lpaaqo=
-github.com/codecrafters-io/tester-utils v0.4.14/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
+github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/test_helpers/scenarios/pass_all/go.mod
+++ b/internal/test_helpers/scenarios/pass_all/go.mod
@@ -10,4 +10,4 @@ module github.com/codecrafters-io/grep-starter-go
 
 go 1.24
 
-require github.com/codecrafters-io/tester-utils v0.4.14
+require github.com/codecrafters-io/tester-utils v0.4.13

--- a/internal/test_helpers/scenarios/pass_all/go.sum
+++ b/internal/test_helpers/scenarios/pass_all/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.14 h1:jJ+b19Il11o/VtIRaaJNOS/HdZLB+yHqJM/P7lpaaqo=
-github.com/codecrafters-io/tester-utils v0.4.14/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
+github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only change that pins `tester-utils` to an earlier version; risk is limited to potential test harness behavior differences.
> 
> **Overview**
> Downgrades `github.com/codecrafters-io/tester-utils` from `v0.4.14` to `v0.4.13` across the main module and the `internal/test_helpers/scenarios/pass_all` fixture, updating the corresponding `go.sum` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6a386b40ee2326eda59249086d6f22dc4a8f171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->