### PR TITLE
Upgrade tester-utils version to remove rlimit_as

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.13
+	github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f
 	github.com/jackpal/bencode-go v1.0.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
-github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f h1:CM8IKArlGpOusbDeEBTzSAIYGXbpZQfw9H14aaIo7IY=
+github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/test_helpers/scenarios/pass_all/go.mod
+++ b/internal/test_helpers/scenarios/pass_all/go.mod
@@ -10,4 +10,4 @@ module github.com/codecrafters-io/grep-starter-go
 
 go 1.24
 
-require github.com/codecrafters-io/tester-utils v0.4.13
+require github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f

--- a/internal/test_helpers/scenarios/pass_all/go.sum
+++ b/internal/test_helpers/scenarios/pass_all/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
-github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f h1:CM8IKArlGpOusbDeEBTzSAIYGXbpZQfw9H14aaIo7IY=
+github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only bump with no application code changes; risk is limited to potential behavior changes inside `tester-utils` affecting test execution.
> 
> **Overview**
> Upgrades `github.com/codecrafters-io/tester-utils` from `v0.4.13` to `v0.4.15-0.20260205181025-90e1af54ed4f` in both the root `go.mod` and `internal/test_helpers/scenarios/pass_all/go.mod`.
> 
> Updates corresponding `go.sum` entries to match the new dependency version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 400cac9756bd390ce2acd14a08c85a3363e2a33b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->