### PR TITLE
CC-2143: Update tester-utils to v0.4.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f
+	github.com/codecrafters-io/tester-utils v0.4.15
 	github.com/jackpal/bencode-go v1.0.2
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f h1:CM8IKArlGpOusbDeEBTzSAIYGXbpZQfw9H14aaIo7IY=
-github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/gLbrqvylwD2oDlc=
+github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -19,8 +19,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/test_helpers/scenarios/pass_all/go.mod
+++ b/internal/test_helpers/scenarios/pass_all/go.mod
@@ -10,4 +10,4 @@ module github.com/codecrafters-io/grep-starter-go
 
 go 1.24
 
-require github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f
+require github.com/codecrafters-io/tester-utils v0.4.15

--- a/internal/test_helpers/scenarios/pass_all/go.sum
+++ b/internal/test_helpers/scenarios/pass_all/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f h1:CM8IKArlGpOusbDeEBTzSAIYGXbpZQfw9H14aaIo7IY=
-github.com/codecrafters-io/tester-utils v0.4.15-0.20260205181025-90e1af54ed4f/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/gLbrqvylwD2oDlc=
+github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
CC-2143: Update tester-utils to v0.4.15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes with no application logic modifications; risk is limited to potential behavioral differences introduced by updated upstream libraries.
> 
> **Overview**
> Bumps `github.com/codecrafters-io/tester-utils` from a pseudo-version to the tagged `v0.4.15` release in both the root module and the `internal/test_helpers/scenarios/pass_all` module.
> 
> Updates `go.sum` accordingly and refreshes the indirect `golang.org/x/sys` dependency to `v0.40.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6886561d23f880e9e9deb84d5b8d2f76acdd87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->